### PR TITLE
fix: dictbuilder

### DIFF
--- a/dictionary/dicbuilder.go
+++ b/dictionary/dicbuilder.go
@@ -24,7 +24,7 @@ const (
 	StringUtf8MaxLength  = 32767
 	StringUtf16MaxLength = 32767
 	ArrayMaxLength       = 127
-	NumberOfColumns      = 18
+	NumberOfColumns      = 19
 	BufferSize           = 1024 * 1024
 )
 
@@ -255,13 +255,13 @@ type writeStringFunc func(buffer *bytes.Buffer, s string) error
 type stringLenFunc func(s string) bool
 
 type DictionaryBuilder struct {
-	trieKeys         *redblacktree.Tree
-	wordEntries      []*wordEntry
-	buffer           *bytes.Buffer
-	position         int64
-	systemLexicon    *DoubleArrayLexicon
-	writeStringF     writeStringFunc
-	stringLen        stringLenFunc
+	trieKeys      *redblacktree.Tree
+	wordEntries   []*wordEntry
+	buffer        *bytes.Buffer
+	position      int64
+	systemLexicon *DoubleArrayLexicon
+	writeStringF  writeStringFunc
+	stringLen     stringLenFunc
 }
 
 func NewDictionaryBuilder(position int64, systemLexicon *DoubleArrayLexicon, utf16string bool) *DictionaryBuilder {
@@ -280,9 +280,9 @@ func NewDictionaryBuilder(position int64, systemLexicon *DoubleArrayLexicon, utf
 			}
 			return len(l) - len(r)
 		}),
-		systemLexicon:    systemLexicon,
-		buffer:           bytes.NewBuffer([]byte{}),
-		position:         position,
+		systemLexicon: systemLexicon,
+		buffer:        bytes.NewBuffer([]byte{}),
+		position:      position,
 	}
 	if utf16string {
 		ret.writeStringF = writeStringUtf16


### PR DESCRIPTION
SudachiDictのカラムが19列あるが、`NumberOfColumns = 18`という長さチェックによって、`bash ../scripts/mksystemdic.sh ../SudachiDict`実行時にエラーになる問題を修正しました。

gosudachiは2019年から更新が止まっていてアクティブなリポジトリか分からず[kagome](https://github.com/ikawaha/kagome)を使おうか悩んでいますが、出来ればpythonの資産を活かしたいのでgosudachiのアップデートを望んでいます。一旦フォークして利用させていただくのでPR作成します。